### PR TITLE
Fix dlrn-api ansible module for actions not returning dicts

### DIFF
--- a/dlrnapi_client/ansible/dlrn_api.py
+++ b/dlrnapi_client/ansible/dlrn_api.py
@@ -286,7 +286,11 @@ def main():
 
     try:
         output = command_funcs[action](api_instance, options)
-        module.exit_json(changed=True, result=output.to_dict())
+        if type(output) == list:
+            output_f = [ x.to_dict() for x in output ]
+        else:
+            output_f = output.to_dict()
+        module.exit_json(changed=True, result=output_f)
     except ApiException as e:
         module.fail_json(msg="Exception when calling "
                              "%s: %s\n" % (command_funcs[action], e))


### PR DESCRIPTION
Some of the dlrn-api calls doesn't return a dict but a
list as repo-status. In those cases ansible module is failing
with error:

'list' object has no attribute 'to_dict'

This patch checks if output is a list and process it in that
case.